### PR TITLE
Temporarily removes lanyrd-Parsing

### DIFF
--- a/src/Command/ParseEvents.php
+++ b/src/Command/ParseEvents.php
@@ -76,7 +76,7 @@ EOT
         $writer->setOutput($output);
 
         $parser = new LanyrdCfpParser();
-        $parser->parse($writer);
+//        $parser->parse($writer);
         $parser = new JoindinCfpParser();
         $parser->parse($writer);
     }


### PR DESCRIPTION
As long as we do not have a written permission to use the data, I'm not
parsing their site.

Request for permission is on it's way