### PR TITLE
Add Twitter-Notification for CfPs ending within 24 hours

### DIFF
--- a/bin/callingallpapers
+++ b/bin/callingallpapers
@@ -15,5 +15,6 @@ use Symfony\Component\Console\Application;
 
 $app = new Application();
 $app->add(new \Callingallpapers\Command\ParseEvents());
+$app->add(new \Callingallpapers\Command\NotifyClosingCfps());
 
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "require": {
         "symfony/console": "^2.7",
         "org_heigl/trait-iterator": "^1.0",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2",
+        "guzzlehttp/oauth-subscriber": "^0.3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bf0ff9543f352cae98a7e84eb7e48c61",
-    "content-hash": "5c746ba644bedd7804180c881f7b5139",
+    "hash": "7629e566f18d7c28d0fa24ac658ae0d5",
+    "content-hash": "8cfa681e4f5fb8f6615306f93c9eb9a0",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -68,6 +68,57 @@
                 "web service"
             ],
             "time": "2016-03-21 20:02:09"
+        },
+        {
+            "name": "guzzlehttp/oauth-subscriber",
+            "version": "0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/oauth-subscriber.git",
+                "reference": "04960cdef3cd80ea401d6b0ca8b3e110e9bf12cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/oauth-subscriber/zipball/04960cdef3cd80ea401d6b0ca8b3e110e9bf12cf",
+                "reference": "04960cdef3cd80ea401d6b0ca8b3e110e9bf12cf",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "~6.0",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Subscriber\\Oauth\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle OAuth 1.0 subscriber",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "oauth"
+            ],
+            "time": "2015-08-15 19:44:28"
         },
         {
             "name": "guzzlehttp/promises",

--- a/config/callingallpapers.ini.dist
+++ b/config/callingallpapers.ini.dist
@@ -20,8 +20,20 @@
 ;
 ; Configuration
 ;
+; What writer shall be used
+writer = "\Callingallpapers\Writer\ApiCfpWriter"
+;
 ; Where shall we write the events to?
 event_api_url = "http://api.callingallpapers.com/v1/cfp"
 ;
 ; What Private API-Token shall we use to write to the API?
 event_api_token = "";
+;
+; TimezoneDB-Access-informations: see https://timezonedb.com/register
+timezonedb_token = ""
+;
+; Twitter-Access Informations: see https://apps.twitter.com/app/new
+twitter.consumer_key =  ""
+twitter.consumer_secret = ""
+twitter.token = ""
+twitter.token_secret = ""

--- a/src/Command/NotifyClosingCfps.php
+++ b/src/Command/NotifyClosingCfps.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright (c) 2015-2016 Andreas Heigl<andreas@heigl.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright 2015-2016 Andreas Heigl/callingallpapers.com
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     01.12.2015
+ * @link      http://github.com/heiglandreas/callingallpapers-cli
+ */
+namespace Callingallpapers\Command;
+
+use Callingallpapers\Notification\NotificationList;
+use Callingallpapers\Notification\TwitterNotifier;
+use Callingallpapers\Reader\ApiCfpReader;
+use Callingallpapers\Service\TwitterNotifierClientFactory;
+use GuzzleHttp\Client;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class NotifyClosingCfps extends Command
+{
+    protected function configure()
+    {
+        $this->setName("notifyClosingCfps")
+             ->setDescription("Notify about CfPs that close within 24 hours")
+             ->setDefinition(array(
+                 new InputOption('start', 's', InputOption::VALUE_OPTIONAL, 'What should be the first date to be taken into account?', ''),
+             ))
+             ->setHelp(<<<EOT
+Notify about CfPs that are closing within 24 hours
+
+Usage:
+
+<info>callingallpapers notifyClosingCfp</info>
+EOT
+             );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $header_style = new OutputFormatterStyle('white', 'green', array('bold'));
+        $output->getFormatter()->setStyle('header', $header_style);
+
+        $start = new \DateTime($input->getOption('start'));
+
+        if (! $start instanceof \DateTime) {
+            throw new \InvalidArgumentException('The given date could not be parsed');
+        }
+
+        $config = parse_ini_file(__DIR__ . '/../../config/callingallpapers.ini');
+        $reader = new ApiCfpReader($config['event_api_url'], $config['event_api_token']);
+        $cfps = $reader->getCfpsEndingWithinInterval(
+            new \DateInterval('PT1H'),
+            (new \DateTimeImmutable())->add(new \DateInterval('PT23H'))
+        );
+
+        $notifications = new NotificationList();
+        $notifications->add(new TwitterNotifier(
+            TwitterNotifierClientFactory::getClient($config)
+        ));
+
+        $notifications->notify($cfps);
+    }
+}

--- a/src/Entity/Cfp.php
+++ b/src/Entity/Cfp.php
@@ -99,6 +99,7 @@ class Cfp
             'location'       => $this->location,
             'latitude'       => (float) $this->latitude,
             'longitude'      => (float) $this->longitude,
+            'timezone'       => $this->timezone,
         );
     }
 }

--- a/src/Notification/NotificationInterface.php
+++ b/src/Notification/NotificationInterface.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright (c) Andreas Heigl<andreas@heigl.org>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright Andreas Heigl
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @since     22.09.2016
+ * @link      http://github.com/heiglandreas/callingallpapers
+ */
+
+namespace Callingallpapers\Notification;
+
+use Callingallpapers\Entity\Cfp;
+
+interface NotificationInterface
+{
+    public function notify(Cfp $cfp);
+}

--- a/src/Notification/NotificationList.php
+++ b/src/Notification/NotificationList.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright (c) Andreas Heigl<andreas@heigl.org>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright Andreas Heigl
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @since     22.09.2016
+ * @link      http://github.com/heiglandreas/callingallpapers
+ */
+
+namespace Callingallpapers\Notification;
+
+use Callingallpapers\Entity\CfpList;
+
+class NotificationList extends \ArrayObject
+{
+    /**
+     * @param mixed $item
+     *
+     * @deprecated
+     * @throws \Exception
+     * @return void
+     */
+    public function append($item)
+    {
+        throw new \Exception(sprintf(
+            'Use %s::add() instead',
+            self::class
+        ));
+    }
+
+    public function add(NotificationInterface $notification)
+    {
+        parent::append($notification);
+    }
+
+    public function notify(CfpList $cfps)
+    {
+        foreach ($cfps as $cfp) {
+            foreach ($this as $notifier) {
+                $notifier->notify($cfp);
+            }
+        }
+    }
+}

--- a/src/Notification/TwitterNotifier.php
+++ b/src/Notification/TwitterNotifier.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright (c) Andreas Heigl<andreas@heigl.org>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright Andreas Heigl
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @since     22.09.2016
+ * @link      http://github.com/heiglandreas/callingallpapers
+ */
+
+namespace Callingallpapers\Notification;
+
+use Callingallpapers\Entity\Cfp;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Request;
+
+class TwitterNotifier implements NotificationInterface
+{
+    protected $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function notify(Cfp $cfp)
+    {
+        $name = $this->shortenName($cfp->conferenceName);
+        $uri  = $this->shortenUri($cfp->uri);
+
+        $notificationString = sprintf(
+            '24 hours until the CfP for "%1$s" closes: %2$s',
+            $name,
+            $uri
+        );
+        $request = new Request('POST',
+            'statuses/update.json?' . $this->formUrlEncode([
+                'status'              => $notificationString,
+                'lat'                 => $cfp->latitude,
+                'long'                => $cfp->longitude,
+                'display_coordinates' => 'true',
+            ]));
+
+        try {
+            $this->client->send($request);
+        } catch (\Exception $e) {
+            //
+        }
+
+    }
+
+    protected function shortenName($name)
+    {
+        if (strlen($name) < 70) {
+            return $name;
+        }
+        return substr($name, 0, 69) . '…';
+    }
+
+    protected function shortenUri($uri)
+    {
+        return $uri;
+    }
+
+    protected function formUrlEncode(array $stuff)
+    {
+        return http_build_query($stuff);
+    }
+}

--- a/src/Parser/Lanyrd/Entry.php
+++ b/src/Parser/Lanyrd/Entry.php
@@ -86,7 +86,9 @@ class Entry
             $cfp->description = $descriptionParser->parse($dom, $xpath);
 
             $openingDateParser = new OpeningDate($timezone);
-            $cfp->dateStart = $openingDateParser->parse($dom, $xpath);
+            try {
+                $cfp->dateStart = $openingDateParser->parse($dom, $xpath);
+            } catch (\Exception $e){}
 
             $cfpUriParser = new Uri();
             $cfp->uri = $cfpUriParser->parse($dom, $xpath);

--- a/src/Parser/Lanyrd/OpeningDate.php
+++ b/src/Parser/Lanyrd/OpeningDate.php
@@ -42,7 +42,7 @@ class OpeningDate
     {
         $openingDate = $xpath->query("//span[text()='Openend on:']/following-sibling::strong");
         if (! $openingDate || $openingDate->length == 0) {
-            return new \DateTime();
+            throw new \UnexpectedValueException('No CfP-Open Date found');
         }
 
         $openingDate = $openingDate->item(0)->textContent;

--- a/src/Reader/ApiCfpReader.php
+++ b/src/Reader/ApiCfpReader.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright (c) 2015-2016 Andreas Heigl<andreas@heigl.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright 2015-2016 Andreas Heigl/callingallpapers.com
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @version   0.0
+ * @since     01.12.2015
+ * @link      http://github.com/heiglandreas/callingallpapers-cli
+ */
+namespace Callingallpapers\Reader;
+
+use Callingallpapers\Entity\Cfp;
+use Callingallpapers\Entity\CfpList;
+use GuzzleHttp\Client;
+
+class ApiCfpReader
+{
+    protected $baseUri;
+
+    protected $bearerToken;
+
+    protected $client;
+
+    public function __construct($baseUri, $bearerToken, $client = null)
+    {
+        $this->baseUri = str_Replace('/cfp', '', $baseUri);
+
+        $this->bearerToken = $bearerToken;
+        if (null === $client) {
+            $client = new Client([
+                'headers' => [
+                    'Accept' => 'application/json',
+                ]
+            ]);
+        }
+        $this->client = $client;
+    }
+
+    /**
+     * @param \DateInterval      $interval
+     * @param \DateTimeInterface $date
+     *
+     * @return CfpList
+     */
+    public function getCfpsEndingWithinInterval(\DateInterval $interval, \DateTimeInterface $date = null)
+    {
+        if (null === $date) {
+            $date = new \DateTimeImmutable();
+        }
+
+        $endDate = $date->add($interval);
+
+        $list = new CfpList();
+
+        try {
+            $result = $this->client->get(sprintf(
+                '%s/search?date_cfp_end[]=%s&date_cfp_end_compare[]=%s&date_cfp_end[]=%s&date_cfp_end_compare[]=%s',
+                $this->baseUri,
+                urlencode($date->setTimezone(new \DateTimeZone('UTC'))->format('c')),
+                urlencode('>'),
+                urlencode($endDate->setTimezone(new \DateTimeZone('UTC'))->format('c')),
+                urlencode('<')
+            ), [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ]
+            ]);
+
+            $items = \GuzzleHttp\json_decode($result->getBody()->getContents(), true);
+
+        } catch (\Exception $e) {
+            return $list;
+        }
+
+        if (! $items) {
+            return $list;
+        }
+
+        foreach ($items['cfps'] as $item) {
+            $cfp = new Cfp();
+            $cfp->conferenceName = $item['name'];
+            $cfp->conferenceUri  = $item['eventUri'];
+            $cfp->dateEnd        = new \DateTimeImmutable($item['dateCfpEnd']);
+            $cfp->dateStart      = new \DateTimeImmutable($item['dateCfpStart']);
+            $cfp->eventDateEnd   = new \DateTimeImmutable($item['dateEventEnd']);
+            $cfp->eventDateStart = new \DateTimeImmutable($item['dateEventStart']);
+            $cfp->description    = $item['description'];
+            $cfp->location       = $item['location'];
+            $cfp->latitude       = $item['latitude'];
+            $cfp->longitude      = $item['longitude'];
+            $cfp->iconUri        = $item['iconUri'];
+            $cfp->uri            = $item['uri'];
+            $cfp->tags           = array_filter($item['tags'], function ($item) {
+                return (bool) $item;
+            });
+            $cfp->timezone       = $item['timezone'];
+
+            $tz = new \DateTimeZone($cfp->timezone);
+
+            $cfp->dateEnd->setTimezone($tz);
+            $cfp->dateStart->setTimezone($tz);
+            $cfp->eventDateEnd->setTimezone($tz);
+            $cfp->eventDateStart->setTimezone($tz);
+
+            $list->append($cfp);
+        }
+
+        return $list;
+    }
+}

--- a/src/Service/TwitterNotifierClientFactory.php
+++ b/src/Service/TwitterNotifierClientFactory.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright (c) Andreas Heigl<andreas@heigl.org>
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author    Andreas Heigl<andreas@heigl.org>
+ * @copyright Andreas Heigl
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
+ * @since     23.09.2016
+ * @link      http://github.com/heiglandreas/callingallpapers
+ */
+
+namespace Callingallpapers\Service;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Subscriber\Oauth\Oauth1;
+
+class TwitterNotifierClientFactory
+{
+    public static function getClient($config)
+    {
+        $stack = HandlerStack::create();
+
+        $oauth = new Oauth1([
+            'consumer_key' => $config['twitter.consumer_key'],
+            'consumer_secret' => $config['twitter.consumer_secret'],
+            'token' => $config['twitter.token'],
+            'token_secret' => $config['twitter.token_secret'],
+        ]);
+
+        $stack->push($oauth);
+
+        $client = new Client([
+            'base_uri' => 'https://api.twitter.com/1.1/',
+            'handler'  => $stack,
+            'auth'     => 'oauth'
+        ]);
+
+        return $client;
+    }
+}

--- a/src/Writer/ApiCfpWriter.php
+++ b/src/Writer/ApiCfpWriter.php
@@ -63,7 +63,6 @@ class ApiCfpWriter implements WriterInterface
     {
         $body = [
             'name'           => $cfp->conferenceName,
-            'dateCfpStart'   => $cfp->dateStart->format('c'),
             'dateCfpEnd'     => $cfp->dateEnd->format('c'),
             'dateEventStart' => $cfp->eventStartDate->format('c'),
             'dateEventEnd'   => $cfp->eventEndDate->format('c'),
@@ -77,6 +76,10 @@ class ApiCfpWriter implements WriterInterface
             'longitude'      => $cfp->longitude,
             'tags'           => $cfp->tags,
         ];
+
+        if ($cfp->dateStart instanceof \DateTimeInterface) {
+            $body['dateCfpStart'] = $cfp->dateStart->format('c');
+        }
 
         try {
             $this->client->request('GET', sprintf(


### PR DESCRIPTION
This PR adds the possibility to send Twitter-Notifications for CfPs that will end within 24 hours. For that a new Command has been added to the CLI that will retrieve all CfPs whose End-Date is higher than now +23 hours and lower than now +24hours.

Adding the Command `./bin/callingallpapers notifyClosingCfps` to an hourly cronjob will send notifications throughout the day depending on the end-date of the CfP.

To accomplish this a notification-API has been created that can be invoked with other commands as well. And there can also be other notifiers that can be hooked into those notifications to add additional endpoints. I could f.e. think of a webhook that is called alongside the twitter-notification or a second notification that will notify of CfPs ending within the next 7 days or....
